### PR TITLE
Move AppVeyor to Node v10

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ build:
 image: Visual Studio 2017
 
 install:
-  - ps: Install-Product node 8 x64
+  - ps: Install-Product node 10 x64
 
 build_script:
     - cmd: fake.cmd build -t CI


### PR DESCRIPTION
It seem that fable uses trimEnd and it only appeared in Node v10

Sending as a PR to trig Appveyor and see if it works